### PR TITLE
Custom gray palette

### DIFF
--- a/docs/.vitepress/theme/theme-default/components/VPFeature.vue
+++ b/docs/.vitepress/theme/theme-default/components/VPFeature.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
-import type { DefaultTheme } from "vitepress/theme";
-import VPImage from "./VPImage.vue";
-import VPLink from "./VPLink.vue";
+import type { DefaultTheme } from "vitepress/theme"
+import VPImage from "./VPImage.vue"
+import VPLink from "./VPLink.vue"
 
 defineProps<{
-  icon?: DefaultTheme.FeatureIcon;
-  title: string;
-  details?: string;
-  link?: string;
-  linkText?: string;
-  rel?: string;
-  target?: string;
-}>();
+  icon?: DefaultTheme.FeatureIcon
+  title: string
+  details?: string
+  link?: string
+  linkText?: string
+  rel?: string
+  target?: string
+}>()
 </script>
 
 <template>
@@ -23,7 +23,7 @@ defineProps<{
     :no-icon="true"
     :tag="link ? 'a' : 'div'"
   >
-    <article class="card tonal">
+    <article class="card outlined">
       <div class="content">
         <div v-if="typeof icon === 'object' && icon.wrap" class="icon">
           <VPImage

--- a/docs/.vitepress/theme/theme-default/styles/vars.css
+++ b/docs/.vitepress/theme/theme-default/styles/vars.css
@@ -286,7 +286,7 @@
     --vp-code-bg: var(--surface-tonal);
 
     --vp-code-block-color: rgba(255, 255, 245, 0.86);
-    --vp-code-block-bg: var(--gray-15, oklch(10% 0.01 255 / 1));
+    --vp-code-block-bg: var(--gray-26, oklch(10% 0.01 255 / 1));
     --vp-code-block-divider-color: #000000;
 
     --vp-code-lang-color: rgba(235, 235, 245, 0.38);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "focus-trap": "^7.6.2",
     "mark.js": "^8.11.1",
     "minisearch": "^7.1.1",
-    "open-props": "^1.7.10",
     "opbeta": "npm:open-props@2.0.0-beta.5",
     "shiki": "^1.24.4",
     "vue": "^3.5.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       opbeta:
         specifier: npm:open-props@2.0.0-beta.5
         version: open-props@2.0.0-beta.5
-      open-props:
-        specifier: ^1.7.10
-        version: 1.7.10
       shiki:
         specifier: ^1.24.4
         version: 1.24.4
@@ -1101,9 +1098,6 @@ packages:
 
   oniguruma-to-es@0.8.1:
     resolution: {integrity: sha512-dekySTEvCxCj0IgKcA2uUCO/e4ArsqpucDPcX26w9ajx+DvMWLc5eZeJaRQkd7oC/+rwif5gnT900tA34uN9Zw==}
-
-  open-props@1.7.10:
-    resolution: {integrity: sha512-zZPJlr39YbHPou7mQ9GUKz1jiYjWzyZf/0pkPZq4MrtwgZ6FSCnf7hLkvFRGq+RZZ327vGSW3HPc7QMH4FUAZg==}
 
   open-props@2.0.0-beta.5:
     resolution: {integrity: sha512-Ahq2/q6T+0kzI9Lwt3f8CX6l0IQxqKYkeMi4u09gdFkFmxB1gYuSwqg2xd5nVN1zEYtUN93V0DbQRoDsP3OSmw==}
@@ -2238,8 +2232,6 @@ snapshots:
       emoji-regex-xs: 1.0.0
       regex: 5.1.1
       regex-recursion: 5.1.1
-
-  open-props@1.7.10: {}
 
   open-props@2.0.0-beta.5: {}
 

--- a/src/actions/button-variants.css
+++ b/src/actions/button-variants.css
@@ -163,10 +163,10 @@
     }
   }
   &.elevated {
-    --_bg-color: light-dark(var(--gray-1), var(--gray-12));
+    --_bg-color: light-dark(var(--gray-2), var(--gray-13));
     --_ripple-color: light-dark(
-      color-mix(in oklch, var(--gray-1) 80%, var(--color-8)),
-      color-mix(in oklch, var(--gray-12) 80%, var(--color-8))
+      color-mix(in oklch, var(--gray-2) 80%, var(--color-8)),
+      color-mix(in oklch, var(--gray-13) 80%, var(--color-8))
     );
     --_text-color: var(--color-8);
 

--- a/src/data-display/badge.css
+++ b/src/data-display/badge.css
@@ -1,7 +1,7 @@
 :where(.badge) {
   --_bg-color: var(--primary);
   --_border-color: var(--primary);
-  --_color: var(--gray-0);
+  --_color: var(--gray-1);
   --_inset-offset: 16px;
   --_inset: auto auto calc(100% - var(--_inset-offset))
     calc(100% - var(--_inset-offset));

--- a/src/data-display/list.css
+++ b/src/data-display/list.css
@@ -6,7 +6,7 @@ Lists meant to be used stand-alone or as part of Select elements
   - .select > .list > option
 */
 :where(.list) {
-  --_bg-color: light-dark(var(--gray-0), var(--gray-14));
+  --_bg-color: light-dark(var(--gray-1), var(--gray-15));
 
   background-color: var(--_bg-color);
   list-style: none;
@@ -145,15 +145,11 @@ Lists meant to be used stand-alone or as part of Select elements
       z-index: 0;
 
       &:hover {
-        background-color: light-dark(var(--gray-1), var(--gray-13));
+        background-color: light-dark(var(--gray-2), var(--gray-14));
       }
 
       &:checked {
-        background-color: color-mix(
-          in oklch,
-          var(--_bg-color) 80%,
-          var(--primary)
-        );
+        background-color: oklch(from var(--primary) l c h / 30%);
       }
     }
 
@@ -188,7 +184,7 @@ Lists meant to be used stand-alone or as part of Select elements
       }
 
       &:hover {
-        background-color: light-dark(var(--gray-1), var(--gray-13));
+        background-color: light-dark(var(--gray-2), var(--gray-14));
       }
 
       /*** Remove ripple effect when trailing button is clicked */

--- a/src/feedback/snackbar.css
+++ b/src/feedback/snackbar.css
@@ -1,7 +1,7 @@
 :where(.snackbar) {
   align-items: center;
   /* Inverse surface-filled */
-  background-color: light-dark(var(--gray-14), var(--gray-1));
+  background-color: light-dark(var(--gray-15), var(--gray-2));
   border-radius: var(--surface-border-radius);
   box-shadow: var(--shadow-2);
   color: var(--text-color-1-contrast);

--- a/src/inputs/file.css
+++ b/src/inputs/file.css
@@ -10,7 +10,7 @@
 
     &::-webkit-file-upload-button,
     &::file-selector-button {
-      background-color: light-dark(var(--gray-1), var(--gray-12));
+      background-color: light-dark(var(--gray-2), var(--gray-13));
       block-size: 100%;
       border: 0;
       border-inline-end: var(--input-border-width) solid

--- a/src/inputs/select.css
+++ b/src/inputs/select.css
@@ -72,7 +72,7 @@
     /* Groups */
     [role="group"] {
       label {
-        background-color: light-dark(var(--gray-2), var(--gray-12));
+        background-color: light-dark(var(--gray-3), var(--gray-13));
         color: light-dark(
           oklch(from var(--text-color-1) calc(l * 0.75) c h),
           oklch(from var(--text-color-1) calc(l * 1.25) c h)

--- a/src/inputs/switch.css
+++ b/src/inputs/switch.css
@@ -2,12 +2,12 @@
   --_accent-color: var(--primary);
   --_accent-contrast: var(--primary-contrast);
 
-  --_dot-bg-color: light-dark(var(--gray-10), var(--gray-13));
+  --_dot-bg-color: light-dark(var(--gray-11), var(--gray-14));
   --_dot-inset: var(--size-1) auto auto var(--size-1);
   --_dot-outline-size: 0;
   --_dot-size: var(--size-3);
 
-  --_track-bg-color: light-dark(var(--gray-2), var(--gray-7));
+  --_track-bg-color: light-dark(var(--gray-3), var(--gray-8));
   --_track-height: var(--size-5);
   --_track-width: var(--size-8);
   --_transition-tf: var(--ease-4);

--- a/src/main.css
+++ b/src/main.css
@@ -11,7 +11,6 @@
 @import "opbeta/css/color/blue.hex.css" layer(props);
 @import "opbeta/css/color/orange.hex.css" layer(props);
 @import "opbeta/css/color/hues.oklch.css" layer(props);
-@import "open-props/gray-oklch.min.css" layer(props);
 
 /* Normalize */
 @import "./normalize.css" layer(normalize);

--- a/src/theme.css
+++ b/src/theme.css
@@ -100,7 +100,7 @@ html {
   --green-text: light-dark(var(--color-1), var(--color-11));
 
   /* Surface */
-  --surface-default: light-dark(var(--gray-1), var(--gray-13));
+  --surface-default: light-dark(var(--gray-1), var(--gray-14));
   --surface-filled: light-dark(var(--gray-2), var(--gray-15));
   --surface-tonal: light-dark(var(--gray-2), var(--gray-13));
   --surface-elevated: light-dark(var(--gray-1), var(--gray-13));

--- a/src/theme.css
+++ b/src/theme.css
@@ -34,18 +34,30 @@ html {
   --palette-hue-rotate-by: 1;
 }
 
+:root {
+  --gray-1: oklch(from var(--color-1) l none h);
+  --gray-2: oklch(from var(--color-2) l none h);
+  --gray-3: oklch(from var(--color-3) l none h);
+  --gray-4: oklch(from var(--color-4) l none h);
+  --gray-5: oklch(from var(--color-5) l none h);
+  --gray-6: oklch(from var(--color-6) l none h);
+  --gray-7: oklch(from var(--color-7) l none h);
+  --gray-8: oklch(from var(--color-8) l none h);
+  --gray-9: oklch(from var(--color-9) l none h);
+  --gray-10: oklch(from var(--color-10) l none h);
+  --gray-11: oklch(from var(--color-11) l none h);
+  --gray-12: oklch(from var(--color-12) l none h);
+  --gray-13: oklch(from var(--color-13) l none h);
+  --gray-14: oklch(from var(--color-14) l none h);
+  --gray-15: oklch(from var(--color-15) l none h);
+  --gray-16: oklch(from var(--color-16) l none h);
+}
+
 /* Theme */
 :where(html) {
   color-scheme: light dark;
 
   /* Colors */
-  /*
-  Palette picker
-  https://opv2-beta.netlify.app/color/
-  */
-  --gray-hue: 255;
-  --gray-chroma: 0.01;
-
   --palette-hue: var(--oklch-teal);
   --palette-hue-rotate-by: 5;
   --palette-chroma: 0.89;
@@ -60,12 +72,12 @@ html {
   --primary: var(--color-8);
   --primary-dark: oklch(from var(--primary) calc(l * 0.75) c h);
   --primary-light: oklch(from var(--primary) calc(l * 1.25) c h);
-  --primary-contrast: var(--gray-0);
+  --primary-contrast: var(--gray-1);
 
-  --text-color-1: light-dark(var(--gray-14), var(--gray-1));
-  --text-color-1-contrast: light-dark(var(--gray-1), var(--gray-14));
-  --text-color-2: light-dark(var(--gray-12), var(--gray-3));
-  --text-color-2-contrast: light-dark(var(--gray-3), var(--gray-12));
+  --text-color-1: light-dark(var(--gray-15), var(--gray-1));
+  --text-color-1-contrast: light-dark(var(--gray-2), var(--gray-15));
+  --text-color-2: light-dark(var(--gray-13), var(--gray-4));
+  --text-color-2-contrast: light-dark(var(--gray-4), var(--gray-13));
 
   --red: var(--red-9);
   --red-light: var(--red-7);
@@ -88,10 +100,10 @@ html {
   --green-text: light-dark(var(--color-1), var(--color-11));
 
   /* Surface */
-  --surface-default: light-dark(var(--gray-0), var(--gray-13));
-  --surface-filled: light-dark(var(--gray-1), var(--gray-14));
-  --surface-tonal: light-dark(var(--gray-1), var(--gray-12));
-  --surface-elevated: light-dark(var(--gray-0), var(--gray-12));
+  --surface-default: light-dark(var(--gray-1), var(--gray-13));
+  --surface-filled: light-dark(var(--gray-2), var(--gray-15));
+  --surface-tonal: light-dark(var(--gray-2), var(--gray-13));
+  --surface-elevated: light-dark(var(--gray-1), var(--gray-13));
   --surface-border-radius: var(--size-1);
 
   /* Typography */
@@ -108,7 +120,7 @@ html {
   --font-size-xs: var(--font-size-0, 0.75rem);
 
   /* Borders */
-  --border-color: light-dark(var(--gray-2), var(--gray-11));
+  --border-color: light-dark(var(--gray-3), var(--gray-11));
   --border-radius: var(--size-1);
   --border-width: 1px;
 


### PR DESCRIPTION
Replaces the OPv1 gray palette with a custom one. The user is allowed to customize their own gray palette to their liking, adjusting all the `l c h` values however they like.

This PR also completely gets rid of OPv1 and now only relies on OPv2 beta.