### PR TITLE
fix/select-browser-spec-documentation

### DIFF
--- a/docs/components/inputs/select.md
+++ b/docs/components/inputs/select.md
@@ -515,6 +515,13 @@ This way of writing Selects are currently quite experimental. Accessible solutio
 
 ## Browser compatibility
 
+<div class="not-rich-text">
+<Alert variant="outlined" severity="warning" title="Experimental Web Platform features feature flag required">
+<p>The Select makes use of the latest <a href="https://una.im/select-updates/" class="link">customizable select API</a> which limits it to Chromium version 133<.</p>
+<p>The <a class="link" href="#non-experimental-select">non-experimental</a> Select is usable today though and might work as a fallback while we wait for the browsers to catch up!</p>
+</Alert>
+</div>
+
 <Baseline :ids="['light-dark', 'color-mix']" />
 
 ## Installation

--- a/src/inputs/select.css
+++ b/src/inputs/select.css
@@ -101,7 +101,14 @@
       /* Option */
       option {
         /* Checkmark */
+        /* TODO - checkmark should be the final version of the checkmark API. Follow the development of this and remove redundant psuedo stuff. */
         &::check {
+          display: none;
+        }
+        &::checkmark {
+          display: none;
+        }
+        &::before {
           display: none;
         }
 


### PR DESCRIPTION
Guard against further Select API changes and document how experimental the Select actually is.

Adresses [this issue](https://github.com/felix-bohlin/ui/issues/97).