### PR TITLE
Refactor pseudo-elements to use double colons

### DIFF
--- a/docs/.vitepress/custom.css
+++ b/docs/.vitepress/custom.css
@@ -17,7 +17,7 @@ html {
   scroll-timeline: --page-scroll block;
 
   &:has(.VPHome) {
-    &:before {
+    &::before {
       background-image: radial-gradient(
         var(--text-color-2) 1.4500000000000002px,
         transparent 1.4500000000000002px
@@ -32,7 +32,7 @@ html {
   }
 
   &.dark {
-    &:before {
+    &::before {
       opacity: 0.075;
     }
   }

--- a/docs/.vitepress/theme/theme-default/styles/components/vp-doc.css
+++ b/docs/.vitepress/theme/theme-default/styles/components/vp-doc.css
@@ -26,7 +26,7 @@
         color 0.25s,
         opacity 0.25s;
 
-      &:before {
+      &::before {
         content: var(--vp-header-anchor-symbol);
       }
     }

--- a/src/actions/icon-button.css
+++ b/src/actions/icon-button.css
@@ -25,7 +25,7 @@
     }
 
     /* Ripple effect, utils > index.css */
-    &:before {
+    &::before {
       --highlight-size: 130%;
     }
 

--- a/src/data-display/badge.css
+++ b/src/data-display/badge.css
@@ -11,7 +11,7 @@
     display: inline-flex;
     position: relative;
 
-    &:after {
+    &::after {
       background-color: var(--_bg-color);
       border: 2px solid var(--_border-color);
       border-radius: 100vmax;
@@ -52,7 +52,7 @@
     /* Dot */
     &.dot {
       --_inset: 0 -1px auto auto;
-      &:after {
+      &::after {
         content: "";
         min-inline-size: var(--size-2);
         block-size: var(--size-2);
@@ -63,7 +63,7 @@
 
     /* Visibility */
     &.invisible {
-      &:after {
+      &::after {
         opacity: 0;
         pointer-events: none;
       }

--- a/src/data-display/definition-list.css
+++ b/src/data-display/definition-list.css
@@ -52,7 +52,7 @@
         }
 
         .term {
-          &:after {
+          &::after {
             display: inline-block;
           }
         }

--- a/src/data-display/list.css
+++ b/src/data-display/list.css
@@ -24,7 +24,7 @@ Lists meant to be used stand-alone or as part of Select elements
     &.bordered {
       :where(li + li, option + option) {
         margin-block-start: var(--size-3);
-        &:before {
+        &::before {
           block-size: 1px;
           border-block-start: 1px solid var(--border-color);
           content: "";
@@ -46,7 +46,7 @@ Lists meant to be used stand-alone or as part of Select elements
 
         &.border-top {
           margin-block-start: var(--size-2);
-          &:before {
+          &::before {
             inset: calc(-1 * var(--size-1)) 0 auto 0;
           }
         }
@@ -113,7 +113,7 @@ Lists meant to be used stand-alone or as part of Select elements
       padding: var(--size-2) var(--size-3);
       position: relative;
 
-      &:before {
+      &::before {
         display: none; /* removing checkmark from option */
       }
 
@@ -221,7 +221,7 @@ Lists meant to be used stand-alone or as part of Select elements
       /* Border between list items */
       &.border-top {
         margin-block-start: var(--size-3);
-        &:before {
+        &::before {
           block-size: 1px;
           border-block-start: 1px solid var(--border-color);
           content: "";

--- a/src/feedback/progress.css
+++ b/src/feedback/progress.css
@@ -57,7 +57,7 @@
     :where(progress):indeterminate {
       animation-direction: reverse;
 
-      &:after {
+      &::after {
         animation-direction: reverse;
       }
     }

--- a/src/feedback/spinner.css
+++ b/src/feedback/spinner.css
@@ -9,7 +9,7 @@
     ) {
     position: relative;
 
-    &:before {
+    &::before {
       animation: spin 0.7s linear infinite;
       border-color: transparent currentColor currentColor;
       border-radius: 50%;
@@ -24,7 +24,7 @@
     }
 
     &:not(button.button):not(:empty) {
-      &:before {
+      &::before {
         margin-inline-end: 0.5em;
       }
     }

--- a/src/inputs/checkbox-radio.css
+++ b/src/inputs/checkbox-radio.css
@@ -63,7 +63,7 @@
         padding-inline: 1ex;
 
         /* Required dot */
-        &:after {
+        &::after {
           inset: 0 -0.25ex auto auto;
         }
       }
@@ -81,7 +81,7 @@
       cursor: pointer;
       inline-size: 1.125rem;
 
-      &:before {
+      &::before {
         --highlight-size: 175%;
       }
     }

--- a/src/inputs/field-group.css
+++ b/src/inputs/field-group.css
@@ -37,7 +37,7 @@
         legend {
           position: relative;
 
-          &:after {
+          &::after {
             color: var(--red);
             content: "*";
             inset: 0 -0.25ex auto auto;

--- a/src/inputs/field.css
+++ b/src/inputs/field.css
@@ -329,7 +329,7 @@
       }
 
       /* Bottom line */
-      &:before {
+      &::before {
         background-color: var(--_filled-border-color);
         block-size: calc(var(--field-border-width) + 1px);
         content: "";
@@ -404,7 +404,7 @@
 
       /* Element states */
       &:hover {
-        &:before {
+        &::before {
           transform: scaleX(1);
         }
       }
@@ -415,7 +415,7 @@
           border-block-end-color: var(--_accent-color);
         }
 
-        &:before {
+        &::before {
           background-color: var(--_accent-color);
           transform: scaleX(1) translateX(0px);
         }
@@ -424,7 +424,7 @@
 
     /* Disabled */
     &:where(:has([disabled])) {
-      &:before {
+      &::before {
         display: none;
       }
       :where(input, textarea, select) {
@@ -439,7 +439,7 @@
 
     /* Read-only */
     &:where(:has([readonly])) {
-      &:before {
+      &::before {
         display: none;
       }
       :where(input, textarea, select) {

--- a/src/inputs/select.css
+++ b/src/inputs/select.css
@@ -10,7 +10,7 @@
 
     &:open {
       button {
-        &:after {
+        &::after {
           rotate: 180deg;
         }
       }
@@ -49,7 +49,7 @@
       position: relative;
 
       /* Arrow */
-      &:after {
+      &::after {
         block-size: 0;
         border-block-start: 5px solid;
         border-inline: 5px solid transparent;
@@ -127,7 +127,7 @@
         padding-block: var(--size-1);
         padding-inline: var(--size-2) var(--size-7);
 
-        &:after {
+        &::after {
           inset-inline-end: var(--size-2);
         }
       }
@@ -144,7 +144,7 @@
       }
 
       /* Arrow */
-      &:after {
+      &::after {
         align-self: center;
         block-size: 0;
         border-block-start: 5px solid;

--- a/src/inputs/switch.css
+++ b/src/inputs/switch.css
@@ -31,7 +31,7 @@
       position: relative;
 
       /* Track */
-      &:before {
+      &::before {
         background-color: var(--_track-bg-color);
         block-size: var(--_track-height);
         border: 1px solid var(--_dot-bg-color);
@@ -48,7 +48,7 @@
       }
 
       /* Dot */
-      &:after {
+      &::after {
         background-color: var(--_dot-bg-color);
         block-size: var(--_dot-size);
         border-radius: 100vmax;
@@ -63,7 +63,7 @@
 
       /* Checked */
       &:checked {
-        &:before {
+        &::before {
           background-color: var(--_accent-color);
           border-color: var(--_accent-color);
           transition:
@@ -72,7 +72,7 @@
         }
 
         /* Dot */
-        &:after {
+        &::after {
           --_dot-bg-color: var(--_accent-contrast);
           --_dot-outline-size: calc(var(--size-1) - 1px);
 
@@ -85,14 +85,14 @@
       /* Animation */
       @media (prefers-reduced-motion: no-preference) {
         /* Track */
-        &:before {
+        &::before {
           transition:
             background-color var(--_transition-time) var(--_transition-tf),
             border-color var(--_transition-time) var(--_transition-tf);
         }
 
         /* Dot */
-        &:after {
+        &::after {
           transition: all var(--_transition-time) var(--_transition-tf);
         }
 

--- a/src/inputs/text-field.css
+++ b/src/inputs/text-field.css
@@ -40,7 +40,7 @@
     .field:has(input[list]):where(:focus-within, :hover)
   ) {
     /* Arrow */
-    &:after {
+    &::after {
       block-size: 0;
       border-block-start: 5px solid;
       border-inline: 5px solid transparent;

--- a/src/utils.css
+++ b/src/utils.css
@@ -34,7 +34,7 @@ When you visibly want to hide an element but make it accessible for screen reade
         --thumb-scale: 1.1;
       }
 
-      &:before {
+      &::before {
         --thumb-scale: 0.01;
         --highlight-size: 150%;
 


### PR DESCRIPTION
Update all CSS pseudo-elements to use the double colon syntax for better compliance with CSS standards.