### PR TITLE
Docs/add main

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -63,6 +63,10 @@ export default defineConfig({
               link: "/guide/getting-started",
               items: [
                 {
+                  text: "Main",
+                  link: "/guide/getting-started/main",
+                },
+                {
                   text: "Normalize",
                   link: "/guide/getting-started/normalize",
                 },

--- a/docs/guide/getting-started/main.md
+++ b/docs/guide/getting-started/main.md
@@ -1,8 +1,7 @@
-
 ---
 overline: Guide
 title: Main
-description: The entry point for all your CSS imports.
+description: The entry point for all CSS imports.
 ---
 
 ::: code-group [main.css]

--- a/docs/guide/getting-started/main.md
+++ b/docs/guide/getting-started/main.md
@@ -1,0 +1,11 @@
+
+---
+overline: Guide
+title: Main
+description: The entry point for all your CSS imports.
+---
+
+::: code-group [main.css]
+<<< @/../src/main.css [main.css]
+:::
+

--- a/docs/guide/getting-started/theme.md
+++ b/docs/guide/getting-started/theme.md
@@ -1,5 +1,5 @@
 ---
-overline: Gude
+overline: Guide
 title: Theme
 ---
 


### PR DESCRIPTION
## Description

 - Added a main.css page in ```../guide/getting-started/main``` to the docs
 - fixed typo in ```../getting-started/theme```   gude -> guide
 - updated ```ui/docs/.vitepress/config.ts``` to reflect new structure 
 
 
