### PR TITLE
Docs: typo

### DIFF
--- a/docs/components/data-display/list.md
+++ b/docs/components/data-display/list.md
@@ -101,7 +101,7 @@ Wrap the elements of your List item with a `a`, `button` or `label` depending on
   <button><!--  --></button>
 </li>
 
-e<li>
+<li>
   <a><!--  --></a>
 </li>
 


### PR DESCRIPTION
	modified:   list.md

## Description

fix typo - removed "e" from html example 
