### PR TITLE
fix(normalize): custom-media

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -5,7 +5,7 @@
 * Import as many props as you need here.
 * https://unpkg.com/browse/open-props@2.0.0-beta.5/css
 */
-@import "opbeta/css/media-queries.css" layer(openprops);
+@import "opbeta/css/media-queries.css";
 @import "opbeta/index.css" layer(openprops);
 @import "opbeta/css/sizes/media.css" layer(openprops);
 @import "opbeta/css/font/lineheight.css" layer(openprops);


### PR DESCRIPTION
remove layer from media-queries import
lightningcss cannot transpile when @layer is defined

## Description

![image](https://github.com/user-attachments/assets/029a4f36-e862-4562-8aef-6aafe40cebbf)
This image is taken from https://open-props-ui.netlify.app/guide/getting-started.html