### PR TITLE
Update checkbox.md

### DIFF
--- a/docs/components/inputs/checkbox.md
+++ b/docs/components/inputs/checkbox.md
@@ -38,13 +38,13 @@ See also: [Checkbox group](#field-group)
 
 <!-- prettier-ignore -->
 ```html
-<!-- Checked -->
+<!-- Unchecked -->
 <label class="checkbox">
   <input name="checkbox" type="checkbox" />
   <span class="sr-only">Label</span>
 </label>
 
-<!-- Unchecked -->
+<!-- Checked -->
 <label class="checkbox">
   <input name="checkbox" type="checkbox" checked="checked" />
   <span class="sr-only">Label</span>


### PR DESCRIPTION
Document Checkbox Typo

## Description

documentation typo for the checkbox example the checked comment and the unchecked comment were backwards :) 
