### PR TITLE
refactor: use opui-css instead of opbeta

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,7 +1,7 @@
 import DefaultTheme from "./theme-default/without-fonts"
 import type { Theme } from "vitepress"
 
-import "../../../src/main.css"
+import "../../../node_modules/opui-css/dist/op+ui.css"
 import "../custom.css"
 
 export default {

--- a/docs/blog/posts/progress-styling.md
+++ b/docs/blog/posts/progress-styling.md
@@ -228,7 +228,7 @@ I ended up reaching for the trusty `:after` pseudo-element. In this case it also
 <template #code>
 
 ::: code-group
-<<< @/../src/feedback/progress.css [progress.css]
+<<< @/../node_modules/opui-css/src/components/progress.css [progress.css]
 
 ```html [progress.html]
 <progress></progress>

--- a/docs/components/actions/button-group.md
+++ b/docs/components/actions/button-group.md
@@ -256,5 +256,5 @@ Create an [issue or a PR](https://github.com/felix-bohlin/ui) and let me know!
 ## Installation
 
 ::: code-group
-<<< @/../src/actions/button-group.css [button-group.css]
+<<< @/../node_modules/opui-css/src/components/button-group.css [button-group.css]
 :::

--- a/docs/components/actions/button.md
+++ b/docs/components/actions/button.md
@@ -377,5 +377,5 @@ These are the classes and attributes a button can be styled with. As usual, feel
 ## Installation
 
 ::: code-group
-<<< @/../src/actions/button.css [button.css]
+<<< @/../node_modules/opui-css/src/components/button.css [button.css]
 :::

--- a/docs/components/actions/icon-button.md
+++ b/docs/components/actions/icon-button.md
@@ -126,5 +126,5 @@ To have an accessible label you can choose between three approaches.
 ## Installation
 
 ::: code-group
-<<< @/../src/actions/icon-button.css [icon-button.css]
+<<< @/../node_modules/opui-css/src/components/icon-button.css [icon-button.css]
 :::

--- a/docs/components/actions/tab-buttons.md
+++ b/docs/components/actions/tab-buttons.md
@@ -45,7 +45,7 @@ title: Tab buttons
 </nav>
 </template>
 <template #code>
-	
+
 ```html
 <nav class="tabs underlined">
   <div role="tablist" aria-label="Underlined tabs">
@@ -172,5 +172,5 @@ There's a lot more. Read about it [here](https://www.w3.org/WAI/ARIA/apg/pattern
 ## Installation
 
 ::: code-group
-<<< @/../src/actions/tab-buttons.css [tab-buttons.css]
+<<< @/../node_modules/opui-css/src/components/tab-buttons.css [tab-buttons.css]
 :::

--- a/docs/components/actions/toggle-button-group.md
+++ b/docs/components/actions/toggle-button-group.md
@@ -363,5 +363,5 @@ Create an [issue or a PR](https://github.com/felix-bohlin/ui) and let me know!
 ## Installation
 
 ::: code-group
-<<< @/../src/actions/toggle-button-group.css [toggle-button-group.css]
+<<< @/../node_modules/opui-css/src/components/toggle-button-group.css [toggle-button-group.css]
 :::

--- a/docs/components/data-display/accordion.md
+++ b/docs/components/data-display/accordion.md
@@ -461,6 +461,6 @@ Accordion has [card](/components/data-display/card) as a dependency.
 </div>
 
 ::: code-group
-<<< @/../src/data-display/accordion.css [accordion.css]
-<<< @/../src/data-display/card.css [card.css]
+<<< @/../node_modules/opui-css/src/components/accordion.css [accordion.css]
+<<< @/../node_modules/opui-css/src/components/card.css [card.css]
 :::

--- a/docs/components/data-display/avatar.md
+++ b/docs/components/data-display/avatar.md
@@ -189,5 +189,5 @@ To get the Avatars to stack like they do below (previous item on top of the next
 ## Installation
 
 ::: code-group
-<<< @/../src/data-display/avatar.css [avatar.css]
+<<< @/../node_modules/opui-css/src/components/avatar.css [avatar.css]
 :::

--- a/docs/components/data-display/badge.md
+++ b/docs/components/data-display/badge.md
@@ -205,4 +205,4 @@ Primary (default), `.error`, `.ok`, `.good`, `.warning`.
 
 ## Installation
 
-<<< @/../src/data-display/badge.css
+<<< @/../node_modules/opui-css/src/components/badge.css

--- a/docs/components/data-display/card.md
+++ b/docs/components/data-display/card.md
@@ -145,5 +145,5 @@ Other components might depend on the card component. Be mindful when making chan
 </div>
 
 ::: code-group
-<<< @/../src/data-display/card.css [card.css]
+<<< @/../node_modules/opui-css/src/components/card.css [card.css]
 :::

--- a/docs/components/data-display/chip.md
+++ b/docs/components/data-display/chip.md
@@ -300,5 +300,5 @@ Make sure the text is wrapped in a `.text` wrapper.
 ## Installation
 
 ::: code-group
-<<< @/../src/data-display/chip.css [chip.css]
+<<< @/../node_modules/opui-css/src/components/chip.css [chip.css]
 :::

--- a/docs/components/data-display/definition-list.md
+++ b/docs/components/data-display/definition-list.md
@@ -144,5 +144,5 @@ import Baseline from "../../.vitepress/theme/app/components/Baseline.vue"
 ## Installation
 
 ::: code-group
-<<< @/../src/data-display/definition-list.css [definition-list.css]
+<<< @/../node_modules/opui-css/src/components/definition-list.css [definition-list.css]
 :::

--- a/docs/components/data-display/divider.md
+++ b/docs/components/data-display/divider.md
@@ -28,4 +28,4 @@ It's just an `<hr>`.
 
 ## Installation
 
-<<< @/../src/data-display/divider.css
+<<< @/../node_modules/opui-css/src/components/divider.css

--- a/docs/components/data-display/list.md
+++ b/docs/components/data-display/list.md
@@ -912,5 +912,5 @@ Simply add the `.dense` class to the `ul` element.
 ## Installation
 
 ::: code-group
-<<< @/../src/data-display/list.css [list.css]
+<<< @/../node_modules/opui-css/src/components/list.css [list.css]
 :::

--- a/docs/components/data-display/table.md
+++ b/docs/components/data-display/table.md
@@ -305,5 +305,5 @@ If you inspect the page you can see that I cheated a bit with the `inset-block-s
 ## Installation
 
 ::: code-group
-<<< @/../src/data-display/table.css [table.css]
+<<< @/../node_modules/opui-css/src/components/table.css [table.css]
 :::

--- a/docs/components/feedback/alert.md
+++ b/docs/components/feedback/alert.md
@@ -201,7 +201,7 @@ There are four different severities - neutral (default), ok, warning, error.
 ## Installation
 
 ::: code-group
-<<< @/../src/feedback/alert.css [alert.css]
+<<< @/../node_modules/opui-css/src/components/alert.css [alert.css]
 
 ```css [theme.css]
 /* ... */

--- a/docs/components/feedback/dialog.md
+++ b/docs/components/feedback/dialog.md
@@ -187,6 +187,6 @@ A `<dialog>` element on its own doesn't do much. It's recommended to use it in c
 ## Installation
 
 ::: code-group
-<<< @/../src/feedback/dialog.css [dialog.css]
-<<< @/../src/data-display/card.css [card.css]
+<<< @/../node_modules/opui-css/src/components/dialog.css [dialog.css]
+<<< @/../node_modules/opui-css/src/components/card.css [card.css]
 :::

--- a/docs/components/feedback/progress.md
+++ b/docs/components/feedback/progress.md
@@ -88,5 +88,5 @@ Source: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
 ## Installation
 
 ::: code-group
-<<< @/../src/feedback/progress.css [progress.css]
+<<< @/../node_modules/opui-css/src/components/progress.css [progress.css]
 :::

--- a/docs/components/feedback/snackbar.md
+++ b/docs/components/feedback/snackbar.md
@@ -284,4 +284,4 @@ That's because when open, popover elements aren't influenced by a parents' `posi
 
 ## Installation
 
-<<< @/../src/feedback/snackbar.css
+<<< @/../node_modules/opui-css/src/components/snackbar.css

--- a/docs/components/feedback/spinner.md
+++ b/docs/components/feedback/spinner.md
@@ -116,5 +116,5 @@ See [progress accessibility](/components/feedback/progress#accessibility) sectio
 ## Installation
 
 ::: code-group
-<<< @/../src/feedback/spinner.css [spinner.css]
+<<< @/../node_modules/opui-css/src/components/spinner.css [spinner.css]
 :::

--- a/docs/components/inputs/checkbox.md
+++ b/docs/components/inputs/checkbox.md
@@ -579,6 +579,6 @@ Accessible checkboxes must have a label. You can choose between three approaches
 ## Installation
 
 ::: code-group
-<<< @/../src/inputs/checkbox-radio.css [checkbox-radio.css]
-<<< @/../src/inputs/field-group.css [field-group.css]
+<<< @/../node_modules/opui-css/src/components/checkbox-radio.css [checkbox-radio.css]
+<<< @/../node_modules/opui-css/src/components/field-group.css [field-group.css]
 :::

--- a/docs/components/inputs/radio.md
+++ b/docs/components/inputs/radio.md
@@ -505,6 +505,6 @@ Accessible radio buttons must have a label. You can choose between three approac
 ## Installation
 
 ::: code-group
-<<< @/../src/inputs/checkbox-radio.css [checkbox-radio.css]
-<<< @/../src/inputs/field-group.css [field-group.css]
+<<< @/../node_modules/opui-css/src/components/checkbox-radio.css [checkbox-radio.css]
+<<< @/../node_modules/opui-css/src/components/field-group.css [field-group.css]
 :::

--- a/docs/components/inputs/range.md
+++ b/docs/components/inputs/range.md
@@ -54,5 +54,5 @@ title: Range
 ## Installation
 
 ::: code-group
-<<< @/../src/inputs/range.css [range.css]
+<<< @/../node_modules/opui-css/src/components/range.css [range.css]
 :::

--- a/docs/components/inputs/select.md
+++ b/docs/components/inputs/select.md
@@ -527,7 +527,7 @@ This way of writing Selects are currently quite experimental. Accessible solutio
 ## Installation
 
 ::: code-group
-<<< @/../src/inputs/field.css [field.css]
-<<< @/../src/inputs/select.css [select.css]
-<<< @/../src/data-display/list.css [list.css]
+<<< @/../node_modules/opui-css/src/components/field.css [field.css]
+<<< @/../node_modules/opui-css/src/components/select.css [select.css]
+<<< @/../node_modules/opui-css/src/components/list.css [list.css]
 :::

--- a/docs/components/inputs/switch.md
+++ b/docs/components/inputs/switch.md
@@ -599,6 +599,6 @@ To have an accessible label you can choose between three approaches.
 ## Installation
 
 ::: code-group
-<<< @/../src/inputs/switch.css [switch.css]
-<<< @/../src/inputs/field-group.css [field-group.css]
+<<< @/../node_modules/opui-css/src/components/switch.css [switch.css]
+<<< @/../node_modules/opui-css/src/components/field-group.css [field-group.css]
 :::

--- a/docs/components/inputs/text-field.md
+++ b/docs/components/inputs/text-field.md
@@ -518,6 +518,6 @@ No. But you get some accessibility wins for free with `<label>`. It's recommende
 ## Installation
 
 ::: code-group
-<<< @/../src/inputs/field.css [field.css]
-<<< @/../src/inputs/text-field.css [text-field.css]
+<<< @/../node_modules/opui-css/src/components/field.css [field.css]
+<<< @/../node_modules/opui-css/src/components/text-field.css [text-field.css]
 :::

--- a/docs/components/inputs/textarea.md
+++ b/docs/components/inputs/textarea.md
@@ -189,6 +189,6 @@ When enabled the Field changes size depending on its content.
 ## Installation
 
 ::: code-group
-<<< @/../src/inputs/field.css [field.css]
-<<< @/../src/inputs/textarea.css [textarea.css]
+<<< @/../node_modules/opui-css/src/components/field.css [field.css]
+<<< @/../node_modules/opui-css/src/components/textarea.css [textarea.css]
 :::

--- a/docs/components/text/rich-text.md
+++ b/docs/components/text/rich-text.md
@@ -270,5 +270,5 @@ What I've written here is probably long enough, but adding this final sentence c
 ## Installation
 
 ::: code-group
-<<< @/../src/text/rich-text.css [rich-text.css]
+<<< @/../node_modules/opui-css/src/components/rich-text.css [rich-text.css]
 :::

--- a/docs/components/text/typography.md
+++ b/docs/components/text/typography.md
@@ -147,5 +147,5 @@ import Alert from "../../.vitepress/theme/app/components/Alert.vue";
 ## Installation
 
 ::: code-group
-<<< @/../src/text/typography.css [typography.css]
+<<< @/../node_modules/opui-css/src/components/typography.css [typography.css]
 :::

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -49,14 +49,26 @@ The setup process will differ a bit if you use a framework, but the core princip
 
 <div class="not-rich-text">
 
+
+`main.css` is the home of all your CSS.
+::: code-group [main.css]
+<<< @/../node_modules/opui-css/src/main.css [main.css]
+:::
+
+`index.css` consists of OPUI imports, only.
+::: code-group [index.css]
+<<< @/../node_modules/opui-css/src/index.css [index.css]
+:::
+
+
 <Accordion variant="tonal" style="margin-block-start: var(--size-3)">
-<template #summary>Setup files</template>
+<template #summary>OPUI core</template>
 
 ::: code-group
-<<< @/../src/main.css [main.css]
-<<< @/../src/normalize.css [normalize.css]
-<<< @/../src/utils.css [utils.css]
-<<< @/../src/theme.css [theme.css]
+<<< @/../node_modules/opui-css/src/core/normalize.css [normalize.css]
+<<< @/../node_modules/opui-css/src/core/utils.css [utils.css]
+<<< @/../node_modules/opui-css/src/core/theme.css [theme.css]
+<<< @/../node_modules/opui-css/src/core/components.css [components.css]
 :::
 
 </Accordion>
@@ -64,23 +76,20 @@ The setup process will differ a bit if you use a framework, but the core princip
 
 ### Folder structure
 
-This is folder structure that comes out of the box. Feel free to change it to your needs.
+This is the folder structure that comes out of the box. Feel free to change it to your needs.
 
 ```
 ├─ main.css
-├─ normalize.css
-├─ theme.css
-├─ utils.css
-├─ actions
+├─ index.css
+├─ core
+│  └─ normalize.css
+│  └─ theme.css
+│  └─ utils.css
+│  └─ components.css
+├─ components
+│  └─ button.css
 │  └─ ...
-├─ data-display
-│  └─ ...
-├─ feedback
-│  └─ ...
-├─ inputs
-│  └─ ...
-└─ text
-   └─ ...
+
 ```
 
 <div class="not-rich-text">

--- a/docs/guide/getting-started/main.md
+++ b/docs/guide/getting-started/main.md
@@ -5,6 +5,6 @@ description: The entry point for all CSS imports.
 ---
 
 ::: code-group [main.css]
-<<< @/../src/main.css [main.css]
+<<< @/../node_modules/opui-css/src/main.css [main.css]
 :::
 

--- a/index.html
+++ b/index.html
@@ -1,845 +1,772 @@
 <!doctype html>
 <html lang="en" color-scheme="default" class="dark">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="stylesheet" href="src/main.css" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>UI</title>
-  </head>
 
-  <body>
-    <div id="top" role="document">
-      <header>
-        <h1>HTML5 Test Page</h1>
-        <p>
-          This is a test page filled with common HTML elements to be used to
-          provide visual feedback whilst building CSS systems and frameworks.
-        </p>
-      </header>
-      <nav>
-        <ul>
-          <li>
-            <a href="#text">Text</a>
-            <ul>
-              <li><a href="#text__headings">Headings</a></li>
-              <li><a href="#text__paragraphs">Paragraphs</a></li>
-              <li><a href="#text__lists">Lists</a></li>
-              <li><a href="#text__blockquotes">Blockquotes</a></li>
-              <li><a href="#text__details">Details / Summary</a></li>
-              <li><a href="#text__address">Address</a></li>
-              <li><a href="#text__hr">Horizontal rules</a></li>
-              <li><a href="#text__tables">Tabular data</a></li>
-              <li><a href="#text__code">Code</a></li>
-              <li><a href="#text__inline">Inline elements</a></li>
-              <li><a href="#text__comments">HTML Comments</a></li>
-            </ul>
-          </li>
-          <li>
-            <a href="#embedded">Embedded content</a>
-            <ul>
-              <li><a href="#embedded__images">Images</a></li>
-              <li><a href="#embedded__bgimages">Background images</a></li>
-              <li><a href="#embedded__audio">Audio</a></li>
-              <li><a href="#embedded__video">Video</a></li>
-              <li><a href="#embedded__canvas">Canvas</a></li>
-              <li><a href="#embedded__meter">Meter</a></li>
-              <li><a href="#embedded__progress">Progress</a></li>
-              <li><a href="#embedded__svg">Inline SVG</a></li>
-              <li><a href="#embedded__iframe">IFrames</a></li>
-              <li><a href="#embedded__embed">Embed</a></li>
-              <li><a href="#embedded__object">Object</a></li>
-            </ul>
-          </li>
-          <li>
-            <a href="#forms">Form elements</a>
-            <ul>
-              <li><a href="#forms__input">Input fields</a></li>
-              <li><a href="#forms__select">Select menus</a></li>
-              <li><a href="#forms__checkbox">Checkboxes</a></li>
-              <li><a href="#forms__radio">Radio buttons</a></li>
-              <li><a href="#forms__textareas">Textareas</a></li>
-              <li><a href="#forms__html5">HTML5 inputs</a></li>
-              <li><a href="#forms__action">Action buttons</a></li>
-            </ul>
-          </li>
-        </ul>
-      </nav>
-      <main>
-        <section id="text">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="node_modules/opui-css/dist/ui.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UI</title>
+</head>
+
+<body>
+  <div id="top" role="document">
+    <header>
+      <h1>HTML5 Test Page</h1>
+      <p>
+        This is a test page filled with common HTML elements to be used to
+        provide visual feedback whilst building CSS systems and frameworks.
+      </p>
+    </header>
+    <nav>
+      <ul>
+        <li>
+          <a href="#text">Text</a>
+          <ul>
+            <li><a href="#text__headings">Headings</a></li>
+            <li><a href="#text__paragraphs">Paragraphs</a></li>
+            <li><a href="#text__lists">Lists</a></li>
+            <li><a href="#text__blockquotes">Blockquotes</a></li>
+            <li><a href="#text__details">Details / Summary</a></li>
+            <li><a href="#text__address">Address</a></li>
+            <li><a href="#text__hr">Horizontal rules</a></li>
+            <li><a href="#text__tables">Tabular data</a></li>
+            <li><a href="#text__code">Code</a></li>
+            <li><a href="#text__inline">Inline elements</a></li>
+            <li><a href="#text__comments">HTML Comments</a></li>
+          </ul>
+        </li>
+        <li>
+          <a href="#embedded">Embedded content</a>
+          <ul>
+            <li><a href="#embedded__images">Images</a></li>
+            <li><a href="#embedded__bgimages">Background images</a></li>
+            <li><a href="#embedded__audio">Audio</a></li>
+            <li><a href="#embedded__video">Video</a></li>
+            <li><a href="#embedded__canvas">Canvas</a></li>
+            <li><a href="#embedded__meter">Meter</a></li>
+            <li><a href="#embedded__progress">Progress</a></li>
+            <li><a href="#embedded__svg">Inline SVG</a></li>
+            <li><a href="#embedded__iframe">IFrames</a></li>
+            <li><a href="#embedded__embed">Embed</a></li>
+            <li><a href="#embedded__object">Object</a></li>
+          </ul>
+        </li>
+        <li>
+          <a href="#forms">Form elements</a>
+          <ul>
+            <li><a href="#forms__input">Input fields</a></li>
+            <li><a href="#forms__select">Select menus</a></li>
+            <li><a href="#forms__checkbox">Checkboxes</a></li>
+            <li><a href="#forms__radio">Radio buttons</a></li>
+            <li><a href="#forms__textareas">Textareas</a></li>
+            <li><a href="#forms__html5">HTML5 inputs</a></li>
+            <li><a href="#forms__action">Action buttons</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+    <main>
+      <section id="text">
+        <header>
+          <h1>Text</h1>
+        </header>
+        <article id="text__headings">
           <header>
-            <h1>Text</h1>
+            <h2>Headings</h2>
           </header>
-          <article id="text__headings">
-            <header>
-              <h2>Headings</h2>
-            </header>
-            <div>
-              <h1>Heading 1</h1>
-              <h2>Heading 2</h2>
-              <h3>Heading 3</h3>
-              <h4>Heading 4</h4>
-              <h5>Heading 5</h5>
-              <h6>Heading 6</h6>
-            </div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__paragraphs">
-            <header>
-              <h2>Paragraphs</h2>
-            </header>
-            <div>
+          <div>
+            <h1>Heading 1</h1>
+            <h2>Heading 2</h2>
+            <h3>Heading 3</h3>
+            <h4>Heading 4</h4>
+            <h5>Heading 5</h5>
+            <h6>Heading 6</h6>
+          </div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__paragraphs">
+          <header>
+            <h2>Paragraphs</h2>
+          </header>
+          <div>
+            <p>
+              A paragraph (from the Greek paragraphos, “to write beside” or
+              “written beside”) is a self-contained unit of a discourse in
+              writing dealing with a particular point or idea. A paragraph
+              consists of one or more sentences. Though not required by the
+              syntax of any language, paragraphs are usually an expected part
+              of formal writing, used to organize longer prose.
+            </p>
+          </div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__blockquotes">
+          <header>
+            <h2>Blockquotes</h2>
+          </header>
+          <div>
+            <blockquote>
               <p>
-                A paragraph (from the Greek paragraphos, “to write beside” or
-                “written beside”) is a self-contained unit of a discourse in
-                writing dealing with a particular point or idea. A paragraph
-                consists of one or more sentences. Though not required by the
-                syntax of any language, paragraphs are usually an expected part
-                of formal writing, used to organize longer prose.
-              </p>
-            </div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__blockquotes">
-            <header>
-              <h2>Blockquotes</h2>
-            </header>
-            <div>
-              <blockquote>
-                <p>
-                  A block quotation (also known as a long quotation or extract)
-                  is a quotation in a written document, that is set off from the
-                  main text as a paragraph, or block of text.
-                </p>
-                <p>
-                  It is typically distinguished visually using indentation and a
-                  different typeface or smaller size quotation. It may or may
-                  not include a citation, usually placed at the bottom.
-                </p>
-                <cite><a href="#!">Said no one, ever.</a></cite>
-              </blockquote>
-            </div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__lists">
-            <header>
-              <h2>Lists</h2>
-            </header>
-            <div>
-              <h3>Definition list</h3>
-              <dl>
-                <dt>Definition List Title</dt>
-                <dd>This is a definition list division.</dd>
-              </dl>
-              <h3>Ordered List</h3>
-              <ol type="1">
-                <li>List Item 1</li>
-                <li>
-                  List Item 2
-                  <ol type="A">
-                    <li>List Item 1</li>
-                    <li>
-                      List Item 2
-                      <ol type="a">
-                        <li>List Item 1</li>
-                        <li>
-                          List Item 2
-                          <ol type="I">
-                            <li>List Item 1</li>
-                            <li>
-                              List Item 2
-                              <ol type="i">
-                                <li>List Item 1</li>
-                                <li>List Item 2</li>
-                                <li>List Item 3</li>
-                              </ol>
-                            </li>
-                            <li>List Item 3</li>
-                          </ol>
-                        </li>
-                        <li>List Item 3</li>
-                      </ol>
-                    </li>
-                    <li>List Item 3</li>
-                  </ol>
-                </li>
-                <li>List Item 3</li>
-              </ol>
-              <h3>Unordered List</h3>
-              <ul>
-                <li>List Item 1</li>
-                <li>
-                  List Item 2
-                  <ul>
-                    <li>List Item 1</li>
-                    <li>
-                      List Item 2
-                      <ul>
-                        <li>List Item 1</li>
-                        <li>
-                          List Item 2
-                          <ul>
-                            <li>List Item 1</li>
-                            <li>
-                              List Item 2
-                              <ul>
-                                <li>List Item 1</li>
-                                <li>List Item 2</li>
-                                <li>List Item 3</li>
-                              </ul>
-                            </li>
-                            <li>List Item 3</li>
-                          </ul>
-                        </li>
-                        <li>List Item 3</li>
-                      </ul>
-                    </li>
-                    <li>List Item 3</li>
-                  </ul>
-                </li>
-                <li>List Item 3</li>
-              </ul>
-            </div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__blockquotes">
-            <header>
-              <h1>Blockquotes</h1>
-            </header>
-            <div>
-              <blockquote>
-                <p>
-                  A block quotation (also known as a long quotation or extract)
-                  is a quotation in a written document, that is set off from the
-                  main text as a paragraph, or block of text.
-                </p>
-                <p>
-                  It is typically distinguished visually using indentation and a
-                  different typeface or smaller size quotation. It may or may
-                  not include a citation, usually placed at the bottom.
-                </p>
-                <cite><a href="#!">Said no one, ever.</a></cite>
-              </blockquote>
-            </div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__details">
-            <header>
-              <h1>Details / Summary</h1>
-            </header>
-            <details>
-              <summary>Expand for details</summary>
-              <p>
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Cum,
-                odio! Odio natus ullam ad quaerat, eaque necessitatibus, aliquid
-                distinctio similique voluptatibus dicta consequuntur animi.
-                Quaerat facilis quidem unde eos! Ipsa.
-              </p>
-            </details>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__address">
-            <header>
-              <h1>Address</h1>
-            </header>
-            <address>
-              Written by
-              <a href="mailto:webmaster@example.com">Jon Doe</a>.<br />
-              Visit us at:<br />
-              Example.com<br />
-              Box 564, Disneyland<br />
-              USA
-            </address>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__hr">
-            <header>
-              <h2>Horizontal rules</h2>
-            </header>
-            <div>
-              <hr />
-            </div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__tables">
-            <header>
-              <h2>Tabular data</h2>
-            </header>
-            <table>
-              <caption>
-                Table Caption
-              </caption>
-              <thead>
-                <tr>
-                  <th>Table Heading 1</th>
-                  <th>Table Heading 2</th>
-                  <th>Table Heading 3</th>
-                  <th>Table Heading 4</th>
-                  <th>Table Heading 5</th>
-                </tr>
-              </thead>
-              <tfoot>
-                <tr>
-                  <th>Table Footer 1</th>
-                  <th>Table Footer 2</th>
-                  <th>Table Footer 3</th>
-                  <th>Table Footer 4</th>
-                  <th>Table Footer 5</th>
-                </tr>
-              </tfoot>
-              <tbody>
-                <tr>
-                  <td>Table Cell 1</td>
-                  <td>Table Cell 2</td>
-                  <td>Table Cell 3</td>
-                  <td>Table Cell 4</td>
-                  <td>Table Cell 5</td>
-                </tr>
-                <tr>
-                  <td>Table Cell 1</td>
-                  <td>Table Cell 2</td>
-                  <td>Table Cell 3</td>
-                  <td>Table Cell 4</td>
-                  <td>Table Cell 5</td>
-                </tr>
-                <tr>
-                  <td>Table Cell 1</td>
-                  <td>Table Cell 2</td>
-                  <td>Table Cell 3</td>
-                  <td>Table Cell 4</td>
-                  <td>Table Cell 5</td>
-                </tr>
-                <tr>
-                  <td>Table Cell 1</td>
-                  <td>Table Cell 2</td>
-                  <td>Table Cell 3</td>
-                  <td>Table Cell 4</td>
-                  <td>Table Cell 5</td>
-                </tr>
-              </tbody>
-            </table>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__code">
-            <header>
-              <h2>Code</h2>
-            </header>
-            <div>
-              <p><strong>Keyboard input:</strong> <kbd>Cmd</kbd></p>
-              <p>
-                <strong>Inline code:</strong>
-                <code>&lt;div&gt;code&lt;/div&gt;</code>
+                A block quotation (also known as a long quotation or extract)
+                is a quotation in a written document, that is set off from the
+                main text as a paragraph, or block of text.
               </p>
               <p>
-                <strong>Sample output:</strong>
-                <samp>This is sample output from a computer program.</samp>
+                It is typically distinguished visually using indentation and a
+                different typeface or smaller size quotation. It may or may
+                not include a citation, usually placed at the bottom.
               </p>
-              <h2>Pre-formatted text</h2>
-              <pre>
+              <cite><a href="#!">Said no one, ever.</a></cite>
+            </blockquote>
+          </div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__lists">
+          <header>
+            <h2>Lists</h2>
+          </header>
+          <div>
+            <h3>Definition list</h3>
+            <dl>
+              <dt>Definition List Title</dt>
+              <dd>This is a definition list division.</dd>
+            </dl>
+            <h3>Ordered List</h3>
+            <ol type="1">
+              <li>List Item 1</li>
+              <li>
+                List Item 2
+                <ol type="A">
+                  <li>List Item 1</li>
+                  <li>
+                    List Item 2
+                    <ol type="a">
+                      <li>List Item 1</li>
+                      <li>
+                        List Item 2
+                        <ol type="I">
+                          <li>List Item 1</li>
+                          <li>
+                            List Item 2
+                            <ol type="i">
+                              <li>List Item 1</li>
+                              <li>List Item 2</li>
+                              <li>List Item 3</li>
+                            </ol>
+                          </li>
+                          <li>List Item 3</li>
+                        </ol>
+                      </li>
+                      <li>List Item 3</li>
+                    </ol>
+                  </li>
+                  <li>List Item 3</li>
+                </ol>
+              </li>
+              <li>List Item 3</li>
+            </ol>
+            <h3>Unordered List</h3>
+            <ul>
+              <li>List Item 1</li>
+              <li>
+                List Item 2
+                <ul>
+                  <li>List Item 1</li>
+                  <li>
+                    List Item 2
+                    <ul>
+                      <li>List Item 1</li>
+                      <li>
+                        List Item 2
+                        <ul>
+                          <li>List Item 1</li>
+                          <li>
+                            List Item 2
+                            <ul>
+                              <li>List Item 1</li>
+                              <li>List Item 2</li>
+                              <li>List Item 3</li>
+                            </ul>
+                          </li>
+                          <li>List Item 3</li>
+                        </ul>
+                      </li>
+                      <li>List Item 3</li>
+                    </ul>
+                  </li>
+                  <li>List Item 3</li>
+                </ul>
+              </li>
+              <li>List Item 3</li>
+            </ul>
+          </div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__blockquotes">
+          <header>
+            <h1>Blockquotes</h1>
+          </header>
+          <div>
+            <blockquote>
+              <p>
+                A block quotation (also known as a long quotation or extract)
+                is a quotation in a written document, that is set off from the
+                main text as a paragraph, or block of text.
+              </p>
+              <p>
+                It is typically distinguished visually using indentation and a
+                different typeface or smaller size quotation. It may or may
+                not include a citation, usually placed at the bottom.
+              </p>
+              <cite><a href="#!">Said no one, ever.</a></cite>
+            </blockquote>
+          </div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__details">
+          <header>
+            <h1>Details / Summary</h1>
+          </header>
+          <details>
+            <summary>Expand for details</summary>
+            <p>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Cum,
+              odio! Odio natus ullam ad quaerat, eaque necessitatibus, aliquid
+              distinctio similique voluptatibus dicta consequuntur animi.
+              Quaerat facilis quidem unde eos! Ipsa.
+            </p>
+          </details>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__address">
+          <header>
+            <h1>Address</h1>
+          </header>
+          <address>
+            Written by
+            <a href="mailto:webmaster@example.com">Jon Doe</a>.<br />
+            Visit us at:<br />
+            Example.com<br />
+            Box 564, Disneyland<br />
+            USA
+          </address>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__hr">
+          <header>
+            <h2>Horizontal rules</h2>
+          </header>
+          <div>
+            <hr />
+          </div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__tables">
+          <header>
+            <h2>Tabular data</h2>
+          </header>
+          <table>
+            <caption>
+              Table Caption
+            </caption>
+            <thead>
+              <tr>
+                <th>Table Heading 1</th>
+                <th>Table Heading 2</th>
+                <th>Table Heading 3</th>
+                <th>Table Heading 4</th>
+                <th>Table Heading 5</th>
+              </tr>
+            </thead>
+            <tfoot>
+              <tr>
+                <th>Table Footer 1</th>
+                <th>Table Footer 2</th>
+                <th>Table Footer 3</th>
+                <th>Table Footer 4</th>
+                <th>Table Footer 5</th>
+              </tr>
+            </tfoot>
+            <tbody>
+              <tr>
+                <td>Table Cell 1</td>
+                <td>Table Cell 2</td>
+                <td>Table Cell 3</td>
+                <td>Table Cell 4</td>
+                <td>Table Cell 5</td>
+              </tr>
+              <tr>
+                <td>Table Cell 1</td>
+                <td>Table Cell 2</td>
+                <td>Table Cell 3</td>
+                <td>Table Cell 4</td>
+                <td>Table Cell 5</td>
+              </tr>
+              <tr>
+                <td>Table Cell 1</td>
+                <td>Table Cell 2</td>
+                <td>Table Cell 3</td>
+                <td>Table Cell 4</td>
+                <td>Table Cell 5</td>
+              </tr>
+              <tr>
+                <td>Table Cell 1</td>
+                <td>Table Cell 2</td>
+                <td>Table Cell 3</td>
+                <td>Table Cell 4</td>
+                <td>Table Cell 5</td>
+              </tr>
+            </tbody>
+          </table>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__code">
+          <header>
+            <h2>Code</h2>
+          </header>
+          <div>
+            <p><strong>Keyboard input:</strong> <kbd>Cmd</kbd></p>
+            <p>
+              <strong>Inline code:</strong>
+              <code>&lt;div&gt;code&lt;/div&gt;</code>
+            </p>
+            <p>
+              <strong>Sample output:</strong>
+              <samp>This is sample output from a computer program.</samp>
+            </p>
+            <h2>Pre-formatted text</h2>
+            <pre>
 P R E F O R M A T T E D T E X T
   ! " # $ % &amp; ' ( ) * + , - . /
   0 1 2 3 4 5 6 7 8 9 : ; &lt; = &gt; ?
   @ A B C D E F G H I J K L M N O
   P Q R S T U V W X Y Z [ \ ] ^ _
   ` a b c d e f g h i j k l m n o
-  p q r s t u v w x y z { | } ~ </pre
-              >
-            </div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__inline">
-            <header>
-              <h2>Inline elements</h2>
-            </header>
-            <div>
-              <p><a href="#!">This is a text link</a>.</p>
-              <p>
-                <strong>Strong is used to indicate strong importance.</strong>
-              </p>
-              <p><em>This text has added emphasis.</em></p>
-              <p>
-                The <b>b element</b> is stylistically different text from normal
-                text, without any special importance.
-              </p>
-              <p>
-                The <i>i element</i> is text that is offset from the normal
-                text.
-              </p>
-              <p>
-                The <u>u element</u> is text with an unarticulated, though
-                explicitly rendered, non-textual annotation.
-              </p>
-              <p>
-                <del>This text is deleted</del> and
-                <ins>This text is inserted</ins>.
-              </p>
-              <p><s>This text has a strikethrough</s>.</p>
-              <p>Superscript<sup>®</sup>.</p>
-              <p>Subscript for things like H<sub>2</sub>O.</p>
-              <p>
-                <small>This small text is small for fine print, etc.</small>
-              </p>
-              <p>
-                Abbreviation:
-                <abbr title="HyperText Markup Language">HTML</abbr>
-              </p>
-              <p>
-                <q
-                  cite="https://developer.mozilla.org/en-US/docs/HTML/Element/q"
-                  >This text is a short inline quotation.</q
-                >
-              </p>
-              <p><cite>This is a citation.</cite></p>
-              <p>The <dfn>dfn element</dfn> indicates a definition.</p>
-              <p>The <mark>mark element</mark> indicates a highlight.</p>
-              <p>
-                The <var>variable element</var>, such as <var>x</var> =
-                <var>y</var>.
-              </p>
-              <p>
-                The time element:
-                <time datetime="2013-04-06T12:32+00:00">2 weeks ago</time>
-              </p>
-            </div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="text__comments">
-            <header>
-              <h2>HTML Comments</h2>
-            </header>
-            <div>
-              <p>
-                There is comment here:
-                <!--This comment should not be displayed-->
-              </p>
-              <p>
-                There is a comment spanning multiple tags and lines below here.
-              </p>
-              <!--<p><a href="#!">This is a text link. But it should not be displayed in a comment</a>.</p>
+  p q r s t u v w x y z { | } ~ </pre>
+          </div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__inline">
+          <header>
+            <h2>Inline elements</h2>
+          </header>
+          <div>
+            <p><a href="#!">This is a text link</a>.</p>
+            <p>
+              <strong>Strong is used to indicate strong importance.</strong>
+            </p>
+            <p><em>This text has added emphasis.</em></p>
+            <p>
+              The <b>b element</b> is stylistically different text from normal
+              text, without any special importance.
+            </p>
+            <p>
+              The <i>i element</i> is text that is offset from the normal
+              text.
+            </p>
+            <p>
+              The <u>u element</u> is text with an unarticulated, though
+              explicitly rendered, non-textual annotation.
+            </p>
+            <p>
+              <del>This text is deleted</del> and
+              <ins>This text is inserted</ins>.
+            </p>
+            <p><s>This text has a strikethrough</s>.</p>
+            <p>Superscript<sup>®</sup>.</p>
+            <p>Subscript for things like H<sub>2</sub>O.</p>
+            <p>
+              <small>This small text is small for fine print, etc.</small>
+            </p>
+            <p>
+              Abbreviation:
+              <abbr title="HyperText Markup Language">HTML</abbr>
+            </p>
+            <p>
+              <q cite="https://developer.mozilla.org/en-US/docs/HTML/Element/q">This text is a short inline
+                quotation.</q>
+            </p>
+            <p><cite>This is a citation.</cite></p>
+            <p>The <dfn>dfn element</dfn> indicates a definition.</p>
+            <p>The <mark>mark element</mark> indicates a highlight.</p>
+            <p>
+              The <var>variable element</var>, such as <var>x</var> =
+              <var>y</var>.
+            </p>
+            <p>
+              The time element:
+              <time datetime="2013-04-06T12:32+00:00">2 weeks ago</time>
+            </p>
+          </div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="text__comments">
+          <header>
+            <h2>HTML Comments</h2>
+          </header>
+          <div>
+            <p>
+              There is comment here:
+              <!--This comment should not be displayed-->
+            </p>
+            <p>
+              There is a comment spanning multiple tags and lines below here.
+            </p>
+            <!--<p><a href="#!">This is a text link. But it should not be displayed in a comment</a>.</p>
               <p><strong>Strong is used to indicate strong importance. But, it should not be displayed in a comment</strong></p>
               <p><em>This text has added emphasis. But, it should not be displayed in a comment</em></p>-->
-            </div>
-                       
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-        </section>
-        <section id="embedded">
+          </div>
+                     
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+      </section>
+      <section id="embedded">
+        <header>
+          <h2>Embedded content</h2>
+        </header>
+        <article id="embedded__images">
           <header>
-            <h2>Embedded content</h2>
+            <h2>Images</h2>
           </header>
-          <article id="embedded__images">
-            <header>
-              <h2>Images</h2>
-            </header>
-            <div>
-              <h3>Plain <code>&lt;img&gt;</code> element</h3>
-              <p>
-                <img
-                  src="https://placekitten.com/480/480"
-                  alt="Photo of a kitten"
-                />
-              </p>
-              <h3>
-                <code>&lt;figure&gt;</code> element with
-                <code>&lt;img&gt;</code> element
-              </h3>
-              <figure>
-                <img
-                  src="https://placekitten.com/480/480"
-                  alt="Photo of a kitten"
-                />
-              </figure>
-              <h3>
-                <code>&lt;figure&gt;</code> element with
-                <code>&lt;img&gt;</code> and
-                <code>&lt;figcaption&gt;</code> elements
-              </h3>
-              <figure>
-                <img
-                  src="https://placekitten.com/480/480"
-                  alt="Photo of a kitten"
-                />
-                <figcaption>Here is a caption for this image.</figcaption>
-              </figure>
-              <h3>
-                <code>&lt;figure&gt;</code> element with a
-                <code>&lt;picture&gt;</code> element
-              </h3>
-              <figure>
-                <picture>
-                  <source
-                    srcset="https://placekitten.com/480/480"
-                    media="(min-width: 800px)"
-                  />
-                  <img
-                    src="https://placekitten.com/480/480"
-                    alt="Photo of a kitten"
-                  />
-                </picture>
-              </figure>
-            </div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="embedded__bgimages">
-            <header>
-              <h2>Background images</h2>
-            </header>
-            <div
-              style="
+          <div>
+            <h3>Plain <code>&lt;img&gt;</code> element</h3>
+            <p>
+              <img src="https://placekitten.com/480/480" alt="Photo of a kitten" />
+            </p>
+            <h3>
+              <code>&lt;figure&gt;</code> element with
+              <code>&lt;img&gt;</code> element
+            </h3>
+            <figure>
+              <img src="https://placekitten.com/480/480" alt="Photo of a kitten" />
+            </figure>
+            <h3>
+              <code>&lt;figure&gt;</code> element with
+              <code>&lt;img&gt;</code> and
+              <code>&lt;figcaption&gt;</code> elements
+            </h3>
+            <figure>
+              <img src="https://placekitten.com/480/480" alt="Photo of a kitten" />
+              <figcaption>Here is a caption for this image.</figcaption>
+            </figure>
+            <h3>
+              <code>&lt;figure&gt;</code> element with a
+              <code>&lt;picture&gt;</code> element
+            </h3>
+            <figure>
+              <picture>
+                <source srcset="https://placekitten.com/480/480" media="(min-width: 800px)" />
+                <img src="https://placekitten.com/480/480" alt="Photo of a kitten" />
+              </picture>
+            </figure>
+          </div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="embedded__bgimages">
+          <header>
+            <h2>Background images</h2>
+          </header>
+          <div style="
                 background-image: url(&quot;https://placekitten.com/480/480&quot;);
                 width: 300px;
                 height: 300px;
-              "
-            ></div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="embedded__audio">
-            <header>
-              <h2>Audio</h2>
-            </header>
-            <div><audio controls="">audio</audio></div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="embedded__video">
-            <header>
-              <h2>Video</h2>
-            </header>
-            <div><video controls="">video</video></div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="embedded__canvas">
-            <header>
-              <h2>Canvas</h2>
-            </header>
-            <div><canvas>canvas</canvas></div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="embedded__meter">
-            <header>
-              <h2>Meter</h2>
-            </header>
-            <div><meter value="2" min="0" max="10">2 out of 10</meter></div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="embedded__progress">
-            <header>
-              <h2>Progress</h2>
-            </header>
-            <div><progress>progress</progress></div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="embedded__svg">
-            <header>
-              <h2>Inline SVG</h2>
-            </header>
-            <div>
-              <svg width="100px" height="100px">
-                <circle cx="100" cy="100" r="100" fill="#1fa3ec"></circle>
-              </svg>
-            </div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="embedded__iframe">
-            <header>
-              <h2>IFrame</h2>
-            </header>
-            <div><iframe src="index.html" height="300"></iframe></div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="embedded__embed">
-            <header>
-              <h2>Embed</h2>
-            </header>
-            <div><embed src="index.html" height="300" /></div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-          <article id="embedded__object">
-            <header>
-              <h2>Object</h2>
-            </header>
-            <div><object data="index.html" height="300"></object></div>
-            <footer>
-              <p><a href="#top">[Top]</a></p>
-            </footer>
-          </article>
-        </section>
-        <section id="forms">
+              "></div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="embedded__audio">
           <header>
-            <h2>Form elements</h2>
+            <h2>Audio</h2>
           </header>
-          <form>
-            <fieldset id="forms__input">
-              <legend>Input fields</legend>
-              <p>
-                <label for="input__text">Text Input</label>
-                <input id="input__text" type="text" placeholder="Text Input" />
-              </p>
-              <p>
-                <label for="input__password">Password</label>
-                <input
-                  id="input__password"
-                  type="password"
-                  placeholder="Type your Password"
-                />
-              </p>
-              <p>
-                <label for="input__webaddress">Web Address</label>
-                <input
-                  id="input__webaddress"
-                  type="url"
-                  placeholder="https://yoursite.com"
-                />
-              </p>
-              <p>
-                <label for="input__emailaddress">Email Address</label>
-                <input
-                  id="input__emailaddress"
-                  type="email"
-                  placeholder="name@email.com"
-                />
-              </p>
-              <p>
-                <label for="input__phone">Phone Number</label>
-                <input
-                  id="input__phone"
-                  type="tel"
-                  placeholder="(999) 999-9999"
-                />
-              </p>
-              <p>
-                <label for="input__search">Search</label>
-                <input
-                  id="input__search"
-                  type="search"
-                  placeholder="Enter Search Term"
-                />
-              </p>
-              <p>
-                <label for="input__text2">Number Input</label>
-                <input
-                  id="input__text2"
-                  type="number"
-                  placeholder="Enter a Number"
-                />
-              </p>
-              <p>
-                <label for="input__file">File Input</label>
-                <input id="input__file" type="file" />
-              </p>
-            </fieldset>
+          <div><audio controls="">audio</audio></div>
+          <footer>
             <p><a href="#top">[Top]</a></p>
-            <fieldset id="forms__select">
-              <legend>Select menus</legend>
-              <p>
-                <label for="select">Select</label>
-                <select id="select">
-                  <optgroup label="Option Group">
-                    <option>Option One</option>
-                    <option>Option Two</option>
-                    <option>Option Three</option>
-                  </optgroup>
-                </select>
-              </p>
-              <p>
-                <label for="select_multiple">Select (multiple)</label>
-                <select id="select_multiple" multiple="multiple">
-                  <optgroup label="Option Group">
-                    <option>Option One</option>
-                    <option>Option Two</option>
-                    <option>Option Three</option>
-                  </optgroup>
-                </select>
-              </p>
-            </fieldset>
+          </footer>
+        </article>
+        <article id="embedded__video">
+          <header>
+            <h2>Video</h2>
+          </header>
+          <div><video controls="">video</video></div>
+          <footer>
             <p><a href="#top">[Top]</a></p>
-            <fieldset id="forms__checkbox">
-              <legend>Checkboxes</legend>
-              <ul>
-                <li>
-                  <label for="checkbox1"
-                    ><input
-                      id="checkbox1"
-                      name="checkbox"
-                      type="checkbox"
-                      checked="checked"
-                    />
-                    Choice A</label
-                  >
-                </li>
-                <li>
-                  <label for="checkbox2"
-                    ><input id="checkbox2" name="checkbox" type="checkbox" />
-                    Choice B</label
-                  >
-                </li>
-                <li>
-                  <label for="checkbox3"
-                    ><input id="checkbox3" name="checkbox" type="checkbox" />
-                    Choice C</label
-                  >
-                </li>
-              </ul>
-            </fieldset>
+          </footer>
+        </article>
+        <article id="embedded__canvas">
+          <header>
+            <h2>Canvas</h2>
+          </header>
+          <div><canvas>canvas</canvas></div>
+          <footer>
             <p><a href="#top">[Top]</a></p>
-            <fieldset id="forms__radio">
-              <legend>Radio buttons</legend>
-              <ul>
-                <li>
-                  <label for="radio1"
-                    ><input
-                      id="radio1"
-                      name="radio"
-                      type="radio"
-                      checked="checked"
-                    />
-                    Option 1</label
-                  >
-                </li>
-                <li>
-                  <label for="radio2"
-                    ><input id="radio2" name="radio" type="radio" /> Option
-                    2</label
-                  >
-                </li>
-                <li>
-                  <label for="radio3"
-                    ><input id="radio3" name="radio" type="radio" /> Option
-                    3</label
-                  >
-                </li>
-              </ul>
-            </fieldset>
+          </footer>
+        </article>
+        <article id="embedded__meter">
+          <header>
+            <h2>Meter</h2>
+          </header>
+          <div><meter value="2" min="0" max="10">2 out of 10</meter></div>
+          <footer>
             <p><a href="#top">[Top]</a></p>
-            <fieldset id="forms__textareas">
-              <legend>Textareas</legend>
-              <p>
-                <label for="textarea">Textarea</label>
-                <textarea
-                  id="textarea"
-                  rows="8"
-                  cols="48"
-                  placeholder="Enter your message here"
-                ></textarea>
-              </p>
-            </fieldset>
+          </footer>
+        </article>
+        <article id="embedded__progress">
+          <header>
+            <h2>Progress</h2>
+          </header>
+          <div><progress>progress</progress></div>
+          <footer>
             <p><a href="#top">[Top]</a></p>
-            <fieldset id="forms__html5">
-              <legend>HTML5 inputs</legend>
-              <p>
-                <label for="ic">Color input</label>
-                <input type="color" id="ic" value="#000000" />
-              </p>
-              <p>
-                <label for="in">Number input</label>
-                <input type="number" id="in" min="0" max="10" value="5" />
-              </p>
-              <p>
-                <label for="ir">Range input</label>
-                <input type="range" id="ir" value="10" />
-              </p>
-              <p>
-                <label for="idd">Date input</label>
-                <input type="date" id="idd" value="1970-01-01" />
-              </p>
-              <p>
-                <label for="idm">Month input</label>
-                <input type="month" id="idm" value="1970-01" />
-              </p>
-              <p>
-                <label for="idw">Week input</label>
-                <input type="week" id="idw" value="1970-W01" />
-              </p>
-              <p>
-                <label for="idt">Datetime input</label>
-                <input type="datetime" id="idt" value="1970-01-01T00:00:00Z" />
-              </p>
-              <p>
-                <label for="idtl">Datetime-local input</label>
-                <input
-                  type="datetime-local"
-                  id="idtl"
-                  value="1970-01-01T00:00"
-                />
-              </p>
-              <p>
-                <label for="idl">Datalist</label>
-                <input type="text" id="idl" list="example-list" />
-                <datalist id="example-list">
-                  <option value="Example #1" />
-                  <option value="Example #2" />
-                  <option value="Example #3" />
-                </datalist>
-              </p>
-            </fieldset>
+          </footer>
+        </article>
+        <article id="embedded__svg">
+          <header>
+            <h2>Inline SVG</h2>
+          </header>
+          <div>
+            <svg width="100px" height="100px">
+              <circle cx="100" cy="100" r="100" fill="#1fa3ec"></circle>
+            </svg>
+          </div>
+          <footer>
             <p><a href="#top">[Top]</a></p>
-            <fieldset id="forms__action">
-              <legend>Action buttons</legend>
-              <p>
-                <input type="submit" value="<input type=submit>" />
-                <input type="button" value="<input type=button>" />
-                <input type="reset" value="<input type=reset>" />
-                <input type="submit" value="<input disabled>" disabled />
-              </p>
-              <p>
-                <button type="submit">&lt;button type=submit&gt;</button>
-                <button type="button">&lt;button type=button&gt;</button>
-                <button type="reset">&lt;button type=reset&gt;</button>
-                <button type="button" disabled>&lt;button disabled&gt;</button>
-              </p>
-            </fieldset>
+          </footer>
+        </article>
+        <article id="embedded__iframe">
+          <header>
+            <h2>IFrame</h2>
+          </header>
+          <div><iframe src="index.html" height="300"></iframe></div>
+          <footer>
             <p><a href="#top">[Top]</a></p>
-          </form>
-        </section>
-      </main>
-      <footer>
-        <p>
-          Made by <a href="http://twitter.com/cbracco">@cbracco</a>. Code on
-          <a href="http://github.com/cbracco/html5-test-page">GitHub</a>.
-        </p>
-      </footer>
-    </div>
-  </body>
+          </footer>
+        </article>
+        <article id="embedded__embed">
+          <header>
+            <h2>Embed</h2>
+          </header>
+          <div><embed src="index.html" height="300" /></div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+        <article id="embedded__object">
+          <header>
+            <h2>Object</h2>
+          </header>
+          <div><object data="index.html" height="300"></object></div>
+          <footer>
+            <p><a href="#top">[Top]</a></p>
+          </footer>
+        </article>
+      </section>
+      <section id="forms">
+        <header>
+          <h2>Form elements</h2>
+        </header>
+        <form>
+          <fieldset id="forms__input">
+            <legend>Input fields</legend>
+            <p>
+              <label for="input__text">Text Input</label>
+              <input id="input__text" type="text" placeholder="Text Input" />
+            </p>
+            <p>
+              <label for="input__password">Password</label>
+              <input id="input__password" type="password" placeholder="Type your Password" />
+            </p>
+            <p>
+              <label for="input__webaddress">Web Address</label>
+              <input id="input__webaddress" type="url" placeholder="https://yoursite.com" />
+            </p>
+            <p>
+              <label for="input__emailaddress">Email Address</label>
+              <input id="input__emailaddress" type="email" placeholder="name@email.com" />
+            </p>
+            <p>
+              <label for="input__phone">Phone Number</label>
+              <input id="input__phone" type="tel" placeholder="(999) 999-9999" />
+            </p>
+            <p>
+              <label for="input__search">Search</label>
+              <input id="input__search" type="search" placeholder="Enter Search Term" />
+            </p>
+            <p>
+              <label for="input__text2">Number Input</label>
+              <input id="input__text2" type="number" placeholder="Enter a Number" />
+            </p>
+            <p>
+              <label for="input__file">File Input</label>
+              <input id="input__file" type="file" />
+            </p>
+          </fieldset>
+          <p><a href="#top">[Top]</a></p>
+          <fieldset id="forms__select">
+            <legend>Select menus</legend>
+            <p>
+              <label for="select">Select</label>
+              <select id="select">
+                <optgroup label="Option Group">
+                  <option>Option One</option>
+                  <option>Option Two</option>
+                  <option>Option Three</option>
+                </optgroup>
+              </select>
+            </p>
+            <p>
+              <label for="select_multiple">Select (multiple)</label>
+              <select id="select_multiple" multiple="multiple">
+                <optgroup label="Option Group">
+                  <option>Option One</option>
+                  <option>Option Two</option>
+                  <option>Option Three</option>
+                </optgroup>
+              </select>
+            </p>
+          </fieldset>
+          <p><a href="#top">[Top]</a></p>
+          <fieldset id="forms__checkbox">
+            <legend>Checkboxes</legend>
+            <ul>
+              <li>
+                <label for="checkbox1"><input id="checkbox1" name="checkbox" type="checkbox" checked="checked" />
+                  Choice A</label>
+              </li>
+              <li>
+                <label for="checkbox2"><input id="checkbox2" name="checkbox" type="checkbox" />
+                  Choice B</label>
+              </li>
+              <li>
+                <label for="checkbox3"><input id="checkbox3" name="checkbox" type="checkbox" />
+                  Choice C</label>
+              </li>
+            </ul>
+          </fieldset>
+          <p><a href="#top">[Top]</a></p>
+          <fieldset id="forms__radio">
+            <legend>Radio buttons</legend>
+            <ul>
+              <li>
+                <label for="radio1"><input id="radio1" name="radio" type="radio" checked="checked" />
+                  Option 1</label>
+              </li>
+              <li>
+                <label for="radio2"><input id="radio2" name="radio" type="radio" /> Option
+                  2</label>
+              </li>
+              <li>
+                <label for="radio3"><input id="radio3" name="radio" type="radio" /> Option
+                  3</label>
+              </li>
+            </ul>
+          </fieldset>
+          <p><a href="#top">[Top]</a></p>
+          <fieldset id="forms__textareas">
+            <legend>Textareas</legend>
+            <p>
+              <label for="textarea">Textarea</label>
+              <textarea id="textarea" rows="8" cols="48" placeholder="Enter your message here"></textarea>
+            </p>
+          </fieldset>
+          <p><a href="#top">[Top]</a></p>
+          <fieldset id="forms__html5">
+            <legend>HTML5 inputs</legend>
+            <p>
+              <label for="ic">Color input</label>
+              <input type="color" id="ic" value="#000000" />
+            </p>
+            <p>
+              <label for="in">Number input</label>
+              <input type="number" id="in" min="0" max="10" value="5" />
+            </p>
+            <p>
+              <label for="ir">Range input</label>
+              <input type="range" id="ir" value="10" />
+            </p>
+            <p>
+              <label for="idd">Date input</label>
+              <input type="date" id="idd" value="1970-01-01" />
+            </p>
+            <p>
+              <label for="idm">Month input</label>
+              <input type="month" id="idm" value="1970-01" />
+            </p>
+            <p>
+              <label for="idw">Week input</label>
+              <input type="week" id="idw" value="1970-W01" />
+            </p>
+            <p>
+              <label for="idt">Datetime input</label>
+              <input type="datetime" id="idt" value="1970-01-01T00:00:00Z" />
+            </p>
+            <p>
+              <label for="idtl">Datetime-local input</label>
+              <input type="datetime-local" id="idtl" value="1970-01-01T00:00" />
+            </p>
+            <p>
+              <label for="idl">Datalist</label>
+              <input type="text" id="idl" list="example-list" />
+              <datalist id="example-list">
+                <option value="Example #1" />
+                <option value="Example #2" />
+                <option value="Example #3" />
+              </datalist>
+            </p>
+          </fieldset>
+          <p><a href="#top">[Top]</a></p>
+          <fieldset id="forms__action">
+            <legend>Action buttons</legend>
+            <p>
+              <input type="submit" value="<input type=submit>" />
+              <input type="button" value="<input type=button>" />
+              <input type="reset" value="<input type=reset>" />
+              <input type="submit" value="<input disabled>" disabled />
+            </p>
+            <p>
+              <button type="submit">&lt;button type=submit&gt;</button>
+              <button type="button">&lt;button type=button&gt;</button>
+              <button type="reset">&lt;button type=reset&gt;</button>
+              <button type="button" disabled>&lt;button disabled&gt;</button>
+            </p>
+          </fieldset>
+          <p><a href="#top">[Top]</a></p>
+        </form>
+      </section>
+    </main>
+    <footer>
+      <p>
+        Made by <a href="http://twitter.com/cbracco">@cbracco</a>. Code on
+        <a href="http://github.com/cbracco/html5-test-page">GitHub</a>.
+      </p>
+    </footer>
+  </div>
+</body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "focus-trap": "^7.6.4",
     "mark.js": "^8.11.1",
     "minisearch": "^7.1.2",
-    "opbeta": "npm:open-props@2.0.0-beta.5",
+    "opui-css": "^1.2.6",
     "shiki": "^3.8.1",
     "vue": "^3.5.17"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,9 @@ importers:
       minisearch:
         specifier: ^7.1.2
         version: 7.1.2
-      opbeta:
-        specifier: npm:open-props@2.0.0-beta.5
-        version: open-props@2.0.0-beta.5
+      opui-css:
+        specifier: ^1.2.6
+        version: 1.2.6
       shiki:
         specifier: ^3.8.1
         version: 3.8.1
@@ -1207,8 +1207,8 @@ packages:
   oniguruma-to-es@4.3.3:
     resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
 
-  open-props@2.0.0-beta.5:
-    resolution: {integrity: sha512-Ahq2/q6T+0kzI9Lwt3f8CX6l0IQxqKYkeMi4u09gdFkFmxB1gYuSwqg2xd5nVN1zEYtUN93V0DbQRoDsP3OSmw==}
+  opui-css@1.2.6:
+    resolution: {integrity: sha512-mW/rTdX3K62vGrFcO0hMiSAePu8ldHLnuxXxjceBzwyHaGUT9JZzh2p+jLLBVnq/6IpVNOw5ZQtG9qcZqNed4w==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -2458,7 +2458,7 @@ snapshots:
       regex: 6.0.1
       regex-recursion: 6.0.2
 
-  open-props@2.0.0-beta.5: {}
+  opui-css@1.2.6: {}
 
   path-browserify@1.0.1: {}
 


### PR DESCRIPTION
Moved over to using the `opui-css` package for all component styles instead of local CSS files. 

**Migration to shared CSS package:**

* All component documentation code samples now import CSS from `node_modules/opui-css/src/components/` instead of local `src/` files

