### PR TITLE
feat: var to control list hover background-color

### DIFF
--- a/src/themes/theme-one/components/list.css
+++ b/src/themes/theme-one/components/list.css
@@ -8,6 +8,7 @@ Lists meant to be used stand-alone or as part of Select elements
 */
   :where(.list) {
     --_bg-color: light-dark(var(--gray-1), var(--gray-15));
+    --_bg-color-hover: light-dark(var(--gray-2), var(--gray-14));
 
     background-color: var(--_bg-color);
     list-style: none;
@@ -146,7 +147,7 @@ Lists meant to be used stand-alone or as part of Select elements
         z-index: 0;
 
         &:hover {
-          background-color: light-dark(var(--gray-2), var(--gray-14));
+          background-color: var(--_bg-color-hover);
         }
 
         &:checked {
@@ -186,7 +187,7 @@ Lists meant to be used stand-alone or as part of Select elements
         }
 
         &:hover {
-          background-color: light-dark(var(--gray-2), var(--gray-14));
+          background-color: var(--_bg-color-hover);
         }
 
         /*** Remove ripple effect when trailing button is clicked */

--- a/src/themes/theme-two/components/list.css
+++ b/src/themes/theme-two/components/list.css
@@ -8,6 +8,7 @@ Lists meant to be used stand-alone or as part of Select elements
 */
   :where(.list) {
     --_bg-color: light-dark(var(--gray-1), var(--gray-15));
+    --_bg-color-hover: light-dark(var(--gray-2), var(--gray-14));
 
     background-color: var(--_bg-color);
     list-style: none;
@@ -146,7 +147,7 @@ Lists meant to be used stand-alone or as part of Select elements
         z-index: 0;
 
         &:hover {
-          background-color: light-dark(var(--gray-2), var(--gray-14));
+          background-color: var(--_bg-color-hover);
         }
 
         &:checked {
@@ -186,7 +187,7 @@ Lists meant to be used stand-alone or as part of Select elements
         }
 
         &:hover {
-          background-color: light-dark(var(--gray-2), var(--gray-14));
+          background-color: var(--_bg-color-hover);
         }
 
         /*** Remove ripple effect when trailing button is clicked */


### PR DESCRIPTION
## Description

Adds support for overriding the hover styles for the List component. I went for pulling the literal css applied out into a variable, easily visible at the top.

### Alternatives

1. Lighten/darken the `--_bg-color` value:
```css
--_bg-color-hover: light-dark(
  oklch(from var(--_bg-color) calc(l * .85) c h / 20%),
  oklch(from var(--_bg-color) calc(l * 2) c h / 20%)
);
```

This seemed a bit error prone depending on the colors someone could set `--_bg-color` to. Maybe it could grab the appropriate `l` value from the gray color palette? But that would only work for gray.

2. Override `--_bg-color` in the hover styles
```css
&:hover {
  --_bg-color: light-dark(var(--gray-2), var(--gray-14));
}
```

This would work but would not allow overriding the styles easily from outside (would have to set custom `&:hover` styles).

(Resolves #283).
